### PR TITLE
point to alpine tarfile; update to docker-gen 0.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ RUN chown -R nginx:nginx /var/lib/nginx
 RUN openssl req -batch -nodes -newkey rsa:2048 -keyout /etc/nginx/server.key -out /tmp/server.csr && \
     openssl x509 -req -days 365 -in /tmp/server.csr -signkey /etc/nginx/server.key -out /etc/nginx/server.crt; rm /tmp/server.csr
 
-ENV DOCKER_GEN_VERSION 0.7.1
+ENV DOCKER_GEN_VERSION 0.7.3
+ENV DOCKER_GEN_TARFILE docker-gen-alpine-linux-amd64-$DOCKER_GEN_VERSION.tar.gz
 
-RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-i386-$DOCKER_GEN_VERSION.tar.gz && \
-	tar -C /usr/local/bin -xvzf docker-gen-linux-i386-$DOCKER_GEN_VERSION.tar.gz && \
-	rm /docker-gen-linux-i386-$DOCKER_GEN_VERSION.tar.gz
+RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/$DOCKER_GEN_TARFILE && \
+	tar -C /usr/local/bin -xvzf $DOCKER_GEN_TARFILE && \
+	rm $DOCKER_GEN_TARFILE
 
 ENV DOCKER_HOST unix:///tmp/docker.sock
 


### PR DESCRIPTION
docker-gen should reference the alpine-linux-amd64 binary. Using the i386 binary fails on a strictly amd64 alpine linux host.